### PR TITLE
Added transformation functions for will* conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,26 +65,33 @@ QUnit.test("test successful promise", 1, function (assert) {
 ### Successful promises
 
 ```
+assert.will(fn, [expectation [, message]])
 assert.will(fn, [message])
 
 - fn: function that returns a promise that should be resolved
+- expectation: function that will evaluate received result and 
+  return true / false if it's correct or wrong
 - message (optional): to push in the log
 ```
 
 ```
-assert.willEqual(fn, expected, [message])
+assert.willEqual(fn, expected, [message], [actualTransform])
 
 - fn: function that returns a promise that should be resolved
 - expected: to compare with the resolved value using ==
 - message (optional): to push in the log
+- actualTransform (optional): function that will transform promise's
+  result for comparison with "expected", e.g. extract a member from object
 ```
 
 ```
-assert.willDeepEqual(fn, expected, [message])
+assert.willDeepEqual(fn, expected, [message], [actualTransform])
 
 - fn: function that returns a promise that should be resolved
 - expected value: to compare with the resolved value using QUnit.equiv
 - message (optional): to push in the log
+- actualTransform (optional): function that will transform promise's
+  result for comparison with "expected", e.g. extract a member from object
 ```
 
 ### Rejected promises

--- a/qunit-promises.js
+++ b/qunit-promises.js
@@ -27,36 +27,43 @@
 
   QUnit.extend(QUnit.assert, {
     // resolved promises
-    will: function (promise, message) {
+    will: function (promise, expectation, message) {
       var always = verifyPromise(promise);
+      if (typeof expectation == 'string') {
+        message = expectation;
+        expectation = function() { return true };
+      }
 
       QUnit.stop();
-      promise.then(function () {
-        QUnit.push(true, undefined, undefined, message);
+      promise.then(function (actual) {
+        QUnit.push(expectation(actual), undefined, undefined, message);
       }, function () {
         QUnit.push(false, undefined, undefined, 'promise rejected (but should have been resolved)');
       })[always](QUnit.start).done();
     },
 
-    willEqual: function (promise, expected, message) {
+    willEqual: function (promise, expected, message, actualTransform) {
       var always = verifyPromise(promise);
-
+      actualTransform = actualTransform || function(actual) {return actual;};
       QUnit.stop();
       promise.then(function (actual) {
+        actual = actualTransform(actual);
         QUnit.push(actual == expected, actual, expected, message);
       }, function (actual) {
         QUnit.push(false, actual, expected, 'promise rejected (but should have been resolved)');
       })[always](QUnit.start).done();
     },
 
-    willDeepEqual: function (promise, expected, message) {
+    willDeepEqual: function (promise, expected, message, actualTransform) {
       var always = verifyPromise(promise);
+      actualTransform = actualTransform || function(actual) {return actual;};
 
       QUnit.stop();
       promise.then(function (actual) {
         if (typeof QUnit.equiv !== 'function') {
           throw new Error('Missing QUnit.equiv function');
         }
+        actual = actualTransform(actual);
         QUnit.push(QUnit.equiv(actual, expected), actual, expected, message);
       }, function (actual) {
         QUnit.push(false, actual, expected, 'promise rejected (but should have been resolved)');

--- a/qunit-promises.js
+++ b/qunit-promises.js
@@ -31,7 +31,7 @@
       var always = verifyPromise(promise);
       if (typeof expectation == 'string') {
         message = expectation;
-        expectation = function() { return true };
+        expectation = function() { return true; };
       }
 
       QUnit.stop();


### PR DESCRIPTION
I have added a parameter to each of the will\* functions that allows to transform the resolved value.

This allows partial comparisons, e.g. actual.length == 100

The .will() function can accept either the message or the function as its second parameter. The other two accept it as their final parameter (they don't perform any detection on parameter type)

Thanks for this great plugin.
